### PR TITLE
refactor(ci): Update actions and remove redundant publish job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,9 @@ jobs:
         python-version: [3.8, 3.9, 3.10, 3.11, 3.12]
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -27,24 +27,3 @@ jobs:
       run: |
         python -m unittest discover tests
 
-  publish:
-    needs: build-and-test
-    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
-    runs-on: ubuntu-latest
-    steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python
-      uses: actions/setup-python@v2
-      with:
-        python-version: '3.x'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install build twine
-    - name: Build package
-      run: python -m build
-    - name: Publish to PyPI
-      uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        user: __token__
-        password: ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
This commit improves the `.github/workflows/ci.yml` file in two ways:

1.  **Updates outdated actions:** The `actions/checkout` and `actions/setup-python` actions have been updated to their latest major versions (`v4` and `v5` respectively). This ensures the workflow uses the most up-to-date features and security fixes.

2.  **Removes redundant publish job:** The `publish` job, which was triggered on tag pushes, has been removed. This job used a legacy token-based authentication method. The repository already has a more modern and secure workflow in `python-publish.yml` that handles publishing to PyPI on releases using trusted publishing (OIDC). Removing the redundant job from `ci.yml` centralizes the release process and improves security.