### PR TITLE
feat: Add hex to UTF-8 decoding and WebSocket support

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,3 +93,35 @@ iran-encoding decode "b'\\x54\\x65\\x73\\x74\\x3a\\x20\\x91\\x9d\\x8f'"
 This will print the decoded string: `Test: تست`
 
 **Note**: You need to wrap the byte string in quotes (`" "`) and prefix it with `b''` to ensure it is correctly parsed by the command line.
+
+### `decode-hex`
+
+The `decode-hex` command decodes a string of hexadecimal characters into text.
+
+```bash
+iran-encoding decode-hex 546573743a20919d8f
+```
+This will print the decoded string: `Test: تست`
+
+## WebSocket Support
+
+This library also provides WebSocket support for both a server and a client.
+
+### WebSocket Server
+
+You can start a WebSocket server that will listen for incoming messages and encode or decode them.
+
+```bash
+iran-encoding ws-server --host 0.0.0.0 --port 8765
+```
+
+The server expects messages in the format `"command:data"`, where `command` is one of `encode`, `decode`, or `decode-hex`.
+
+### WebSocket Client
+
+You can use the WebSocket client to send a message to the server and receive the response.
+
+```bash
+iran-encoding ws-client ws://localhost:8765 "encode:سلام"
+```
+This will send the message `"encode:سلام"` to the server and print the response.

--- a/iran_encoding/__init__.py
+++ b/iran_encoding/__init__.py
@@ -79,3 +79,19 @@ def decode(data: bytes) -> str:
     logical_text = _process_bidi(visual_text, reverse_rtl=True)
 
     return logical_text
+
+def decode_hex(hex_string: str) -> str:
+    """
+    Decodes a hex string into a UTF-8 string using the Iran System map.
+
+    Args:
+        hex_string: The input hex string to decode.
+
+    Returns:
+        The decoded string.
+    """
+    try:
+        data = bytes.fromhex(hex_string)
+        return decode(data)
+    except (ValueError, TypeError):
+        return "Error: Invalid hex string"

--- a/iran_encoding/cli.py
+++ b/iran_encoding/cli.py
@@ -3,7 +3,9 @@ This module provides the command-line interface for the iran-encoding package.
 """
 import argparse
 import ast
-from iran_encoding import encode, decode
+import asyncio
+from iran_encoding import encode, decode, decode_hex
+from . import websockets as ws
 
 def main():
     """The main entry point for the CLI."""
@@ -17,6 +19,20 @@ def main():
     # Decode command
     decode_parser = subparsers.add_parser("decode", help="Decode a byte string.")
     decode_parser.add_argument("data", type=str, help="The byte string to decode (e.g., \"b'\\xde\\xad'\").")
+
+    # Decode-hex command
+    decode_hex_parser = subparsers.add_parser("decode-hex", help="Decode a hex string.")
+    decode_hex_parser.add_argument("hex_string", type=str, help="The hex string to decode (e.g., 'deadbeef').")
+
+    # WebSocket server command
+    ws_server_parser = subparsers.add_parser("ws-server", help="Start a WebSocket server.")
+    ws_server_parser.add_argument("--host", type=str, default="localhost", help="Host to bind the server to.")
+    ws_server_parser.add_argument("--port", type=int, default=8765, help="Port to bind the server to.")
+
+    # WebSocket client command
+    ws_client_parser = subparsers.add_parser("ws-client", help="Connect to a WebSocket server.")
+    ws_client_parser.add_argument("uri", type=str, help="The URI of the WebSocket server.")
+    ws_client_parser.add_argument("message", type=str, help="The message to send to the server (e.g., 'encode:سلام').")
 
     args = parser.parse_args()
 
@@ -40,6 +56,20 @@ def main():
         except (ValueError, SyntaxError, TypeError) as e:
             print(f"Error: Invalid input for decoding. {e}")
             exit(1)
+    elif args.command == "decode-hex":
+        try:
+            decoded_result = decode_hex(args.hex_string)
+            print(decoded_result)
+        except Exception as e:
+            print(f"Error: {e}")
+            exit(1)
+    elif args.command == "ws-server":
+        try:
+            asyncio.run(ws.server(args.host, args.port))
+        except KeyboardInterrupt:
+            print("Server stopped.")
+    elif args.command == "ws-client":
+        asyncio.run(ws.client(args.uri, args.message))
 
 if __name__ == "__main__":
     main()

--- a/iran_encoding/mappings.py
+++ b/iran_encoding/mappings.py
@@ -53,8 +53,12 @@ IRAN_SYSTEM_MAP = {
 }
 
 # Create a reverse map for encoding: from character to hex code.
-# Note: Some characters map to multiple codes. We take the first one found.
-REVERSE_IRAN_SYSTEM_MAP = {char: code for code, char in IRAN_SYSTEM_MAP.items() if len(char) == 1}
+# We iterate through the map and overwrite entries. This ensures that the *last*
+# occurrence of a character in the map is the one that is used.
+REVERSE_IRAN_SYSTEM_MAP = {}
+for code, char in IRAN_SYSTEM_MAP.items():
+    if len(char) == 1:
+        REVERSE_IRAN_SYSTEM_MAP[char] = code
 
 # Define a fallback character code for characters not in the map.
 UNKNOWN_CHAR_CODE = REVERSE_IRAN_SYSTEM_MAP.get('?', 0x3F)

--- a/iran_encoding/websockets.py
+++ b/iran_encoding/websockets.py
@@ -1,0 +1,41 @@
+import asyncio
+import websockets
+from . import encode, decode, decode_hex
+
+async def handler(websocket, path):
+    """
+    WebSocket handler that processes incoming messages.
+    """
+    async for message in websocket:
+        try:
+            # The message should be in the format "command:data"
+            command, data = message.split(":", 1)
+
+            if command == "encode":
+                response = encode(data).hex()
+            elif command == "decode":
+                response = decode(bytes.fromhex(data))
+            elif command == "decode_hex":
+                response = decode_hex(data)
+            else:
+                response = f"Error: Unknown command '{command}'"
+        except Exception as e:
+            response = f"Error: {e}"
+
+        await websocket.send(response)
+
+async def server(host, port):
+    """
+    Starts the WebSocket server.
+    """
+    async with websockets.serve(handler, host, port):
+        await asyncio.Future()  # run forever
+
+async def client(uri, message):
+    """
+    Connects to the WebSocket server, sends a message, and prints the response.
+    """
+    async with websockets.connect(uri) as websocket:
+        await websocket.send(message)
+        response = await websocket.recv()
+        print(response)

--- a/setup.py
+++ b/setup.py
@@ -20,6 +20,9 @@ setup(
         "Topic :: Text Processing :: General",
     ],
     python_requires=">=3.6",
+    install_requires=[
+        "websockets>=10.0",
+    ],
     entry_points={
         "console_scripts": [
             "iran-encoding=iran_encoding.cli:main",

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 import unittest
-from iran_encoding import encode, decode
+from iran_encoding import encode, decode, decode_hex
 from iran_encoding.mappings import REVERSE_IRAN_SYSTEM_MAP, IRAN_SYSTEM_MAP
 
 class TestIranSystemEncoding(unittest.TestCase):
@@ -75,6 +75,18 @@ class TestIranSystemEncoding(unittest.TestCase):
                 encoded = encode(char)
                 decoded = decode(encoded)
                 self.assertEqual(char, decoded)
+
+    def test_decode_hex(self):
+        """Test decoding from a hex string."""
+        text = "Test: تست"
+        encoded = encode(text)
+        hex_string = encoded.hex()
+        decoded = decode_hex(hex_string)
+        self.assertEqual(text, decoded)
+
+    def test_decode_hex_invalid_string(self):
+        """Test decoding from an invalid hex string."""
+        self.assertIn("Error", decode_hex("invalid hex"))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -1,0 +1,37 @@
+import asyncio
+import unittest
+from unittest.mock import MagicMock, AsyncMock
+from iran_encoding import websockets as ws
+
+class TestWebSockets(unittest.TestCase):
+
+    async def run_handler_test(self, message, expected_response):
+        websocket = MagicMock()
+        # Ensure the mock is awaitable and can be used in an async for loop
+        websocket.__aiter__.return_value = [message]
+        websocket.send = AsyncMock()
+
+        await ws.handler(websocket, "/")
+
+        if expected_response.startswith("Error:"):
+            self.assertTrue(websocket.send.call_args[0][0].startswith("Error:"))
+        else:
+            websocket.send.assert_called_once_with(expected_response)
+
+    def test_handler_encode(self):
+        asyncio.run(self.run_handler_test("encode:سلام", "ed8ef8e5"))
+
+    def test_handler_decode(self):
+        asyncio.run(self.run_handler_test("decode:ed8ef8e5", "سلام"))
+
+    def test_handler_decode_hex(self):
+        asyncio.run(self.run_handler_test("decode_hex:ed8ef8e5", "سلام"))
+
+    def test_handler_unknown_command(self):
+        asyncio.run(self.run_handler_test("unknown:test", "Error: Unknown command 'unknown'"))
+
+    def test_handler_invalid_message(self):
+        asyncio.run(self.run_handler_test("invalid_message", "Error: not enough values to unpack"))
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
This commit introduces two new features:

1.  **Hex to UTF-8 Decoding:**
    - A `decode_hex` function has been added to the library to convert a hex string to a UTF-8 string.
    - A `decode-hex` command has been added to the CLI.

2.  **WebSocket Support:**
    - The library now supports WebSocket-based communication for encoding and decoding.
    - A `ws-server` command has been added to start a WebSocket server.
    - A `ws-client` command has been added to connect to the server and send messages.
    - The `websockets` library has been added as a dependency.

Both features are accompanied by unit tests and documentation updates.