### PR TITLE
Fix visual ordering for Persian letter 'Pe' at start of words

### DIFF
--- a/iran_encoding/__init__.py
+++ b/iran_encoding/__init__.py
@@ -8,7 +8,7 @@ ensuring consistent behavior and professional results.
 import re
 from .core import unicode_to_iransystem, iransystem_to_unicode
 
-__version__ = "1.1.0"
+__version__ = "1.1.2"
 __author__ = "Community Contributors"
 __all__ = ['encode', 'decode', 'decode_hex', 'detect_locale']
 

--- a/iran_encoding/core.py
+++ b/iran_encoding/core.py
@@ -140,8 +140,9 @@ def reverse_alpha_numeric(in_bytes: bytes) -> bytes:
         current = in_bytes[byte_count] if byte_count < length else 0xFF
 
         # Trigger reversal on Persian letters or special markers
-        # In Iran System, letters start from 0x8D (excluding some symbols)
-        is_trigger = (current > 0x8C and current != 0xFF) or current < 0x20 or current == 0x8E or current == 0x8F
+        # In Iran System, letters start from 0x8D (excluding Pe and some symbols)
+        is_trigger = (current > 0x8C and current != 0xFF) or current < 0x20 or \
+                     current == 0x8E or current == 0x8F or current == 0x81
         if is_trigger or byte_count == length:
             if (byte_count - number_position) > 1:
                 for number_count in range(number_position, byte_count):

--- a/iran_encoding/iran_system.c
+++ b/iran_encoding/iran_system.c
@@ -137,8 +137,9 @@ void ReverseAlphaNumeric(unsigned char *inString, unsigned char *outString) {
     for (byteCount = 0; byteCount <= len; byteCount++) {
         unsigned char current = (byteCount < len) ? inString[byteCount] : 0xFF;
 
-        // Trigger reversal on Persian letters or special markers
-        int is_trigger = (current > 0x8C && current != 0xFF) || current < 0x20 || current == 0x8E || current == 0x8F;
+        // Trigger reversal on Persian letters (including Pe at 0x81) or special markers
+        int is_trigger = (current > 0x8C && current != 0xFF) || current < 0x20 || \
+                         current == 0x8E || current == 0x8F || current == 0x81;
         if (is_trigger || byteCount == len) {
             if ((byteCount - numberPosition) > 1) {
                 for (numberCount = numberPosition; numberCount < byteCount; numberCount++) {

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ requirements = ["setuptools>=65.0.0"]
 
 setup(
     name="iran-encoding",
-    version="1.1.1",
+    version="1.1.2",
     author="Iran System encoding",
     author_email="Iran-System-encoding@movtigroup.ir",
     description="Professional Iran System encoding library with Persian/English support",

--- a/tests/test_pe_issue.py
+++ b/tests/test_pe_issue.py
@@ -1,0 +1,64 @@
+import pytest
+import iran_encoding
+
+def test_pe_at_start():
+    """
+    Test that 'Pe' at the start of a word (possibly after a space)
+    is correctly handled by visual ordering.
+    """
+    text = "پلیس"
+    encoded = iran_encoding.encode(text)
+    # encoded:
+    # 'پلیس' (logical)
+    # script: 81 e1 ed d3
+    # reverse_alpha_numeric (if 81 is trigger): d3 ed e1 81
+    # unicode_to_iransystem logic (reshaping):
+    # d3 -> isolated sin (a7)
+    # ed -> medial ye (fe)
+    # e1 -> medial lam (f3)
+    # 81 -> initial pe (95)
+    # result: a7 fe f3 95
+    # final reversal: 95 f3 fe a7
+
+    # Wait, my reproduce_bug.py showed:
+    # Text: 'پلیس'
+    # Hex:  a7 fe f3 95
+    # Decoded: 'پلیس'
+
+    # Let's check " پلیس" (space + پلیس)
+    text_with_space = " پلیس"
+    encoded_with_space = iran_encoding.encode(text_with_space)
+    # Currently: a7 fe f3 20 94
+    # Expected: 95 f3 fe a7 20
+
+    print(f"\nHex for ' پلیس': {encoded_with_space.hex(' ')}")
+
+    # If it's correctly ordered, ' ' (20) should be at the end (left-most in visual)
+    # or start depending on how we define it, but it should NOT be in the middle of the word.
+
+    # In Iran System, visual 95 f3 fe a7 20 means " پلیس"
+    # Current output a7 fe f3 20 94 means " پ لیس" (because 20 interrupted the word)
+
+    assert encoded_with_space.endswith(b'\x20') or encoded_with_space.startswith(b'\x20')
+    # Actually, visual RTL means if Unicode is " پلیس",
+    # visual order should be "س ی ل پ "
+    # Hex: a7 fe f3 95 20
+
+    assert encoded_with_space.hex() == "a7fef39520"
+
+def test_pe_vs_be():
+    """Compare 'Pe' behavior with 'Be' which works."""
+    be_text = " بلیس"
+    pe_text = " پلیس"
+
+    be_encoded = iran_encoding.encode(be_text)
+    pe_encoded = iran_encoding.encode(pe_text)
+
+    # be_encoded should be a7 fe f3 93 20
+    # pe_encoded should be a7 fe f3 95 20
+
+    assert be_encoded.endswith(b'\x20')
+    assert pe_encoded.endswith(b'\x20'), f"Pe encoded as {pe_encoded.hex()} should end with space"
+
+if __name__ == "__main__":
+    pytest.main([__file__])


### PR DESCRIPTION
The intermediate script code for 'Pe' (0x81) was missing from the trigger list in the visual ordering logic (reverse_alpha_numeric). This caused 'Pe' to be treated as LTR/numeric when preceded by a space, leading to broken words and incorrect character shaping. This fix adds 0x81 to the RTL trigger conditions in both Python and C implementations.

---
*PR created automatically by Jules for task [12352832550418937304](https://jules.google.com/task/12352832550418937304) started by @tahatehran*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Refined the character reversal mechanism in Persian text encoding to properly handle additional character sequences and edge cases, improving overall encoding accuracy and ensuring correct visual rendering.

* **Tests**
  * Added new test cases covering Persian character encoding scenarios with various character combinations.

* **Chores**
  * Package version updated to 1.1.2.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/movtigroup/Iran-System-encoding/pull/33?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->